### PR TITLE
Voucherify (Actions) to main

### DIFF
--- a/packages/destination-actions/src/destinations/voucherify/addCustomEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/voucherify/addCustomEvent/generated-types.ts
@@ -2,25 +2,37 @@
 
 export interface Payload {
   /**
-   * The source_id which identifies the [customer](https://docs.voucherify.io/reference/the-customer-object) in Voucherify.
+   * This is an object containing information about the [customer](https://docs.voucherify.io/reference/the-customer-object).
    */
-  source_id: string
+  customer?: {
+    source_id?: string
+    email?: string
+  }
   /**
-   * The email that identifies the [customer](https://docs.voucherify.io/reference/the-customer-object) in Voucherify.
+   * If a conversion event for a referral program is set to a [custom event](https://docs.voucherify.io/reference/custom-event-object), then you need to send the referral code in the payload to make a record of the conversion event.
    */
-  email?: string
+  referral?: {
+    code?: string
+    referrer_id?: string
+  }
   /**
-   * The name of the event that will be saved as a [custom event](https://docs.voucherify.io/reference/the-custom-event-object) in Voucherify.
+   * If an earning rule in a loyalty program is based on a [custom event](https://docs.voucherify.io/reference/custom-event-object). This objects allows you specify the loyalty card to which the custom event should be attributed to.
    */
-  event?: string
+  loyalty?: {
+    code?: string
+  }
   /**
-   * Additional data that will be stored in the [custom event](https://docs.voucherify.io/reference/the-custom-event-object) metadata in Voucherify.
+   * The metadata object stores all custom attributes assigned to the [custom event](https://docs.voucherify.io/reference/custom-event-object). A set of key/value pairs that you can attach to an event object. It can be useful for storing additional information about the event in a structured format. Event metadata schema is defined in the Dashboard > Project Settings > Event Schema > Edit particular event > Metadata property definition.
    */
   metadata?: {
     [k: string]: unknown
   }
   /**
-   * Type of the event. It can be track, page or screen.
+   * The name of the event that will be saved as a [custom event](https://docs.voucherify.io/reference/the-custom-event-object) in Voucherify.
+   */
+  event?: string
+  /**
+   * Type of the [event](https://segment.com/docs/connections/spec/). It can be Track, Page or Screen.
    */
   type: string
 }

--- a/packages/destination-actions/src/destinations/voucherify/addCustomEvent/index.ts
+++ b/packages/destination-actions/src/destinations/voucherify/addCustomEvent/index.ts
@@ -9,31 +9,74 @@ const action: ActionDefinition<Settings, Payload> = {
     'Send the Track, Page or Screen event that will be saved as a [custom event](https://docs.voucherify.io/reference/the-custom-event-object) in Voucherify.',
   defaultSubscription: 'type = "track" or type = "page" or type = "screen"',
   fields: {
-    source_id: {
-      label: 'Source ID',
+    customer: {
+      label: 'customer',
       description:
-        'The source_id which identifies the [customer](https://docs.voucherify.io/reference/the-customer-object) in Voucherify.',
-      type: 'string',
-      required: true,
+        'This is an object containing information about the [customer](https://docs.voucherify.io/reference/the-customer-object).',
+      type: 'object',
+      properties: {
+        source_id: {
+          label: 'Source Id',
+          type: 'string'
+        },
+        email: {
+          label: 'Email',
+          type: 'string'
+        }
+      },
       default: {
-        '@if': {
-          exists: { '@path': '$.userId' },
-          then: { '@path': '$.userId' },
-          else: { '@path': '$.anonymousId' }
+        source_id: { '@path': '$.userId' },
+        email: {
+          '@if': {
+            exists: { '@path': '$.properties.email' },
+            then: { '@path': '$.properties.email' },
+            else: { '@path': '$.context.traits' }
+          }
         }
       }
     },
-    email: {
-      label: 'Email Address',
+    referral: {
+      label: 'referral',
       description:
-        'The email that identifies the [customer](https://docs.voucherify.io/reference/the-customer-object) in Voucherify.',
-      type: 'string',
-      default: {
-        '@if': {
-          exists: { '@path': '$.properties.email' },
-          then: { '@path': '$.properties.email' },
-          else: { '@path': '$.context.traits' }
+        'If a conversion event for a referral program is set to a [custom event](https://docs.voucherify.io/reference/custom-event-object), then you need to send the referral code in the payload to make a record of the conversion event.',
+      type: 'object',
+      properties: {
+        code: {
+          label: 'code',
+          type: 'string'
+        },
+        referrer_id: {
+          label: 'referrer_id',
+          type: 'string'
         }
+      },
+      default: {
+        code: { '@path': '$.properties.referral.code' },
+        referrer_id: { '@path': '$.properties.referral.referrer_id' }
+      }
+    },
+    loyalty: {
+      label: 'loyalty',
+      description:
+        'If an earning rule in a loyalty program is based on a [custom event](https://docs.voucherify.io/reference/custom-event-object). This objects allows you specify the loyalty card to which the custom event should be attributed to.',
+      type: 'object',
+      properties: {
+        code: {
+          label: 'code',
+          type: 'string'
+        }
+      },
+      default: {
+        code: { '@path': '$.properties.loyalty.code' }
+      }
+    },
+    metadata: {
+      label: 'Track Event Metadata',
+      description:
+        'The metadata object stores all custom attributes assigned to the [custom event](https://docs.voucherify.io/reference/custom-event-object). A set of key/value pairs that you can attach to an event object. It can be useful for storing additional information about the event in a structured format. Event metadata schema is defined in the Dashboard > Project Settings > Event Schema > Edit particular event > Metadata property definition.',
+      type: 'object',
+      default: {
+        '@path': '$.properties.metadata'
       }
     },
     event: {
@@ -49,18 +92,9 @@ const action: ActionDefinition<Settings, Payload> = {
         }
       }
     },
-    metadata: {
-      label: 'Track Event Metadata',
-      description:
-        'Additional data that will be stored in the [custom event](https://docs.voucherify.io/reference/the-custom-event-object) metadata in Voucherify.',
-      type: 'object',
-      default: {
-        '@path': '$.properties'
-      }
-    },
     type: {
       label: 'Event Type',
-      description: 'Type of the event. It can be track, page or screen.',
+      description: 'Type of the [event](https://segment.com/docs/connections/spec/). It can be Track, Page or Screen.',
       type: 'string',
       required: true,
       default: {

--- a/packages/destination-actions/src/destinations/voucherify/assignCustomerToGroup/generated-types.ts
+++ b/packages/destination-actions/src/destinations/voucherify/assignCustomerToGroup/generated-types.ts
@@ -10,7 +10,7 @@ export interface Payload {
    */
   email?: string
   /**
-   * The ID used to uniquely identify a group to which customer belongs.
+   * The ID used to uniquely identify a group to which [customer](https://docs.voucherify.io/reference/the-customer-object) belongs.
    */
   group_id: string
   /**

--- a/packages/destination-actions/src/destinations/voucherify/assignCustomerToGroup/index.ts
+++ b/packages/destination-actions/src/destinations/voucherify/assignCustomerToGroup/index.ts
@@ -14,13 +14,7 @@ const action: ActionDefinition<Settings, Payload> = {
         'The source_id which identifies the [customer](https://docs.voucherify.io/reference/the-customer-object) in Voucherify.',
       type: 'string',
       required: true,
-      default: {
-        '@if': {
-          exists: { '@path': '$.userId' },
-          then: { '@path': '$.userId' },
-          else: { '@path': '$.anonymousId' }
-        }
-      }
+      default: { '@path': '$.userId' }
     },
     email: {
       label: 'Email Address',
@@ -33,7 +27,8 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     group_id: {
       label: 'Group ID',
-      description: 'The ID used to uniquely identify a group to which customer belongs.',
+      description:
+        'The ID used to uniquely identify a group to which [customer](https://docs.voucherify.io/reference/the-customer-object) belongs.',
       type: 'string',
       required: true,
       default: {

--- a/packages/destination-actions/src/destinations/voucherify/upsertCustomer/generated-types.ts
+++ b/packages/destination-actions/src/destinations/voucherify/upsertCustomer/generated-types.ts
@@ -2,33 +2,55 @@
 
 export interface Payload {
   /**
-   * The source_id which identifies the [customer](https://docs.voucherify.io/reference/the-customer-object) in Voucherify.
+   * The `source_id` which identifies the [customer](https://docs.voucherify.io/reference/the-customer-object) in Voucherify.
    */
   source_id: string
+  /**
+   * First name and last name of the [customer](https://docs.voucherify.io/reference/customer-object).
+   */
+  name?: string
+  /**
+   * First name of the [customer](https://docs.voucherify.io/reference/customer-object). It will be merged with `lastName` to create the `name` field.
+   */
+  firstName?: string
+  /**
+   * Last name of the [customer](https://docs.voucherify.io/reference/customer-object). It will be merged with `firstName` to create the `name` field.
+   */
+  lastName?: string
+  /**
+   * An arbitrary string that you can attach to a [customer](https://docs.voucherify.io/reference/customer-object) object.
+   */
+  description?: string
   /**
    * The email that identifies the [customer](https://docs.voucherify.io/reference/the-customer-object) in Voucherify.
    */
   email?: string
   /**
-   * Additional [customer](https://docs.voucherify.io/reference/the-customer-object) attributes, such as email, name, description, phone, address, birthdate, metadata. When updating a customer, attributes are either added or updated in the customer object.
+   * Phone number of the [customer](https://docs.voucherify.io/reference/the-customer-object).
    */
-  traits?: {
-    firstName?: string
-    lastName?: string
-    name?: string
-    description?: string
-    address?: {
-      [k: string]: unknown
-    }
-    phone?: string
-    birthdate?: string
-    metadata?: {
-      [k: string]: unknown
-    }
+  phone?: string
+  /**
+   * Birthdate of the [customer](https://docs.voucherify.io/reference/the-customer-object). You can pass data here in `date` or `datetime` format (ISO 8601).
+   */
+  birthdate?: string
+  /**
+   * Address of the [customer](https://docs.voucherify.io/reference/the-customer-object).
+   */
+  address?: {
+    city?: string
+    state?: string
+    postalCode?: string
+    street?: string
+    country?: string
+  }
+  /**
+   * A set of custom key/value pairs that you can attach to a customer. The metadata object stores all custom attributes assigned to the customer. It can be useful for storing additional information about the customer in a structured format.
+   */
+  metadata?: {
     [k: string]: unknown
   }
   /**
-   * Type of the event [The Segment Spec](https://segment.com/docs/connections/spec/).
+   * Type of the [event](https://segment.com/docs/connections/spec/).
    */
   type: string
 }

--- a/packages/destination-actions/src/destinations/voucherify/upsertCustomer/index.ts
+++ b/packages/destination-actions/src/destinations/voucherify/upsertCustomer/index.ts
@@ -12,15 +12,44 @@ const action: ActionDefinition<Settings, Payload> = {
     source_id: {
       label: 'Source ID',
       description:
-        'The source_id which identifies the [customer](https://docs.voucherify.io/reference/the-customer-object) in Voucherify.',
+        'The `source_id` which identifies the [customer](https://docs.voucherify.io/reference/the-customer-object) in Voucherify.',
       type: 'string',
       required: true,
+      default: { '@path': '$.userId' }
+    },
+    name: {
+      label: 'Name',
+      description: 'First name and last name of the [customer](https://docs.voucherify.io/reference/customer-object).',
+      type: 'string',
       default: {
-        '@if': {
-          exists: { '@path': '$.userId' },
-          then: { '@path': '$.userId' },
-          else: { '@path': '$.anonymousId' }
-        }
+        '@path': '$.traits.name'
+      }
+    },
+    firstName: {
+      label: 'First Name',
+      description:
+        'First name of the [customer](https://docs.voucherify.io/reference/customer-object). It will be merged with `lastName` to create the `name` field.',
+      type: 'string',
+      default: {
+        '@path': '$.traits.first_name'
+      }
+    },
+    lastName: {
+      label: 'Last Name',
+      description:
+        'Last name of the [customer](https://docs.voucherify.io/reference/customer-object). It will be merged with `firstName` to create the `name` field.',
+      type: 'string',
+      default: {
+        '@path': '$.traits.last_name'
+      }
+    },
+    description: {
+      label: 'Description',
+      description:
+        'An arbitrary string that you can attach to a [customer](https://docs.voucherify.io/reference/customer-object) object.',
+      type: 'string',
+      default: {
+        '@path': '$.traits.description'
       }
     },
     email: {
@@ -32,62 +61,69 @@ const action: ActionDefinition<Settings, Payload> = {
         '@path': '$.traits.email'
       }
     },
-    traits: {
-      label: 'Customer Attributes',
+    phone: {
+      label: 'Phone',
+      description: 'Phone number of the [customer](https://docs.voucherify.io/reference/the-customer-object).',
+      type: 'string',
+      default: {
+        '@path': '$.traits.phone'
+      }
+    },
+    birthdate: {
+      label: 'Birthdate',
       description:
-        'Additional [customer](https://docs.voucherify.io/reference/the-customer-object) attributes, such as email, name, description, phone, address, birthdate, metadata. When updating a customer, attributes are either added or updated in the customer object.',
-      additionalProperties: true,
-      defaultObjectUI: 'keyvalue',
+        'Birthdate of the [customer](https://docs.voucherify.io/reference/the-customer-object). You can pass data here in `date` or `datetime` format (ISO 8601).',
+      type: 'string',
+      default: {
+        '@path': '$.traits.birthdate'
+      }
+    },
+    address: {
+      label: 'Address',
+      description: 'Address of the [customer](https://docs.voucherify.io/reference/the-customer-object).',
       type: 'object',
       properties: {
-        firstName: {
-          label: 'First Name',
+        city: {
+          label: 'City',
           type: 'string'
         },
-        lastName: {
-          label: 'Last Name',
+        state: {
+          label: 'State',
           type: 'string'
         },
-        name: {
-          label: 'Name',
+        postalCode: {
+          label: 'Postal Code',
           type: 'string'
         },
-        description: {
-          label: 'Description',
+        street: {
+          label: 'Street',
           type: 'string'
         },
-        address: {
-          label: 'Address',
-          type: 'object'
-        },
-        phone: {
-          label: 'Phone',
+        country: {
+          label: 'Country',
           type: 'string'
-        },
-        birthdate: {
-          label: 'Birthdate',
-          type: 'string'
-        },
-        metadata: {
-          label: 'Metadata',
-          type: 'object'
         }
       },
       default: {
-        firstName: { '@path': '$.traits.first_name' },
-        lastName: { '@path': '$.traits.last_name' },
-        name: { '@path': '$.traits.name' },
-        description: { '@path': '$.traits.description' },
-        address: { '@path': '$.traits.address' },
-        phone: { '@path': '$.traits.phone' },
-        birthdate: { '@path': '$.traits.birthdate' },
-        metadata: { '@path': '$.traits.metadata' }
+        city: { '@path': '$.traits.address.city' },
+        state: { '@path': '$.traits.address.state' },
+        postalCode: { '@path': '$.traits.address.postal_code' },
+        street: { '@path': '$.traits.address.street' },
+        country: { '@path': '$.traits.address.country' }
       }
     },
-
+    metadata: {
+      label: 'Metadata',
+      description:
+        'A set of custom key/value pairs that you can attach to a customer. The metadata object stores all custom attributes assigned to the customer. It can be useful for storing additional information about the customer in a structured format.',
+      type: 'object',
+      default: {
+        '@path': '$.traits.metadata'
+      }
+    },
     type: {
       label: 'Event Type',
-      description: 'Type of the event [The Segment Spec](https://segment.com/docs/connections/spec/).',
+      description: 'Type of the [event](https://segment.com/docs/connections/spec/).',
       type: 'string',
       required: true,
       default: {


### PR DESCRIPTION
## What 
- [x] Updated the description of the fields and objects to match the current documentation: https://docs.voucherify.io/reference/custom-event-object
https://docs.voucherify.io/reference/customer-object
- [x] Added new objects to custom event: loyalty, referral and customer.
- [x] Moved the customer attributes to the "main" object in customer processing. We no longer use the traits object in which we were sending data to Voucherify.\

## How it looks now

https://github.com/rspective/action-destinations/assets/117282008/971134b5-6e2f-4799-b42e-578d409757f5

## Why
https://3.basecamp.com/3108604/buckets/27411519/messages/5707074673#__recording_6212232605