### PR TITLE
Add allowNull option to customer attributes

### DIFF
--- a/packages/destination-actions/src/destinations/voucherify/upsertCustomer/generated-types.ts
+++ b/packages/destination-actions/src/destinations/voucherify/upsertCustomer/generated-types.ts
@@ -12,11 +12,11 @@ export interface Payload {
   /**
    * First name of the [customer](https://docs.voucherify.io/reference/customer-object). It will be merged with `last_name` to create the `name` field.
    */
-  first_name?: string
+  first_name?: string | null
   /**
    * Last name of the [customer](https://docs.voucherify.io/reference/customer-object). It will be merged with `first_name` to create the `name` field.
    */
-  last_name?: string
+  last_name?: string | null
   /**
    * An arbitrary string that you can attach to a [customer](https://docs.voucherify.io/reference/customer-object) object.
    */

--- a/packages/destination-actions/src/destinations/voucherify/upsertCustomer/generated-types.ts
+++ b/packages/destination-actions/src/destinations/voucherify/upsertCustomer/generated-types.ts
@@ -8,7 +8,7 @@ export interface Payload {
   /**
    * First name and last name of the [customer](https://docs.voucherify.io/reference/customer-object).
    */
-  name?: string
+  name?: string | null
   /**
    * First name of the [customer](https://docs.voucherify.io/reference/customer-object). It will be merged with `last_name` to create the `name` field.
    */
@@ -20,35 +20,35 @@ export interface Payload {
   /**
    * An arbitrary string that you can attach to a [customer](https://docs.voucherify.io/reference/customer-object) object.
    */
-  description?: string
+  description?: string | null
   /**
    * The email that identifies the [customer](https://docs.voucherify.io/reference/the-customer-object) in Voucherify.
    */
-  email?: string
+  email?: string | null
   /**
    * Phone number of the [customer](https://docs.voucherify.io/reference/the-customer-object).
    */
-  phone?: string
+  phone?: string | null
   /**
    * Birthdate of the [customer](https://docs.voucherify.io/reference/the-customer-object). You can pass data here in `date` or `datetime` format (ISO 8601).
    */
-  birthdate?: string
+  birthdate?: string | null
   /**
    * Address of the [customer](https://docs.voucherify.io/reference/the-customer-object).
    */
   address?: {
-    city?: string
-    state?: string
-    postal_code?: string
-    street?: string
-    country?: string
+    city?: string | null
+    state?: string | null
+    postal_code?: string | null
+    street?: string | null
+    country?: string | null
   }
   /**
    * A set of custom key/value pairs that you can attach to a customer. The metadata object stores all custom attributes assigned to the customer. It can be useful for storing additional information about the customer in a structured format.
    */
   metadata?: {
     [k: string]: unknown
-  }
+  } | null
   /**
    * Type of the [event](https://segment.com/docs/connections/spec/). For example: identify, track, page, screen or group
    */

--- a/packages/destination-actions/src/destinations/voucherify/upsertCustomer/index.ts
+++ b/packages/destination-actions/src/destinations/voucherify/upsertCustomer/index.ts
@@ -28,6 +28,7 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     first_name: {
       label: 'First Name',
+      allowNull: true,
       description:
         'First name of the [customer](https://docs.voucherify.io/reference/customer-object). It will be merged with `last_name` to create the `name` field.',
       type: 'string',
@@ -37,6 +38,7 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     last_name: {
       label: 'Last Name',
+      allowNull: true,
       description:
         'Last name of the [customer](https://docs.voucherify.io/reference/customer-object). It will be merged with `first_name` to create the `name` field.',
       type: 'string',

--- a/packages/destination-actions/src/destinations/voucherify/upsertCustomer/index.ts
+++ b/packages/destination-actions/src/destinations/voucherify/upsertCustomer/index.ts
@@ -19,6 +19,7 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     name: {
       label: 'Name',
+      allowNull: true,
       description: 'First name and last name of the [customer](https://docs.voucherify.io/reference/customer-object).',
       type: 'string',
       default: {
@@ -45,6 +46,7 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     description: {
       label: 'Description',
+      allowNull: true,
       description:
         'An arbitrary string that you can attach to a [customer](https://docs.voucherify.io/reference/customer-object) object.',
       type: 'string',
@@ -54,6 +56,7 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     email: {
       label: 'Email Address',
+      allowNull: true,
       description:
         'The email that identifies the [customer](https://docs.voucherify.io/reference/the-customer-object) in Voucherify.',
       type: 'string',
@@ -63,6 +66,7 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     phone: {
       label: 'Phone',
+      allowNull: true,
       description: 'Phone number of the [customer](https://docs.voucherify.io/reference/the-customer-object).',
       type: 'string',
       default: {
@@ -71,6 +75,7 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     birthdate: {
       label: 'Birthdate',
+      allowNull: true,
       description:
         'Birthdate of the [customer](https://docs.voucherify.io/reference/the-customer-object). You can pass data here in `date` or `datetime` format (ISO 8601).',
       type: 'string',
@@ -85,23 +90,28 @@ const action: ActionDefinition<Settings, Payload> = {
       properties: {
         city: {
           label: 'City',
-          type: 'string'
+          type: 'string',
+          allowNull: true
         },
         state: {
           label: 'State',
-          type: 'string'
+          type: 'string',
+          allowNull: true
         },
         postal_code: {
           label: 'Postal Code',
-          type: 'string'
+          type: 'string',
+          allowNull: true
         },
         street: {
           label: 'Street',
-          type: 'string'
+          type: 'string',
+          allowNull: true
         },
         country: {
           label: 'Country',
-          type: 'string'
+          type: 'string',
+          allowNull: true
         }
       },
       default: {
@@ -117,6 +127,7 @@ const action: ActionDefinition<Settings, Payload> = {
       description:
         'A set of custom key/value pairs that you can attach to a customer. The metadata object stores all custom attributes assigned to the customer. It can be useful for storing additional information about the customer in a structured format.',
       type: 'object',
+      allowNull: true,
       default: {
         '@path': '$.traits.metadata'
       }


### PR DESCRIPTION
## What
Added `allowNull` flag for customer attributes (expect the `source_id`).

## Why
https://github.com/rspective/voucherify-mono/pull/15094